### PR TITLE
Cache para permisos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 /vendor/
 .htaccess
 .env
-/cache/login_attempts/*.txt
+/cache/

--- a/.htaccess
+++ b/.htaccess
@@ -1,11 +1,15 @@
-# Activa el motor de reescritura
 RewriteEngine On
 
-# Redirige todas las solicitudes a la carpeta 'public/'
+# Evita redirigir si ya estamos en /public
+RewriteCond %{REQUEST_URI} !^/public/
+
+# Redirige todo a public/
 RewriteRule ^(.*)$ public/$1 [L]
-RewriteRule ^(src|config|model|core|docs|test|vendor) - [F,L,NC]
-# Bloquea acceso a archivos sensibles (opcional pero recomendado)
-<FilesMatch "\.(env|log|sql|htaccess|gitignore|md)|composer.(json|lock)$">
+
+# Bloquea acceso a carpetas sensibles desde la raíz
+RewriteRule ^(src|config|model|core|docs|test|vendor|cache) - [F,L,NC]
+
+<FilesMatch "\.(env|log|sql|htaccess|gitignore|md)|composer\.(json|lock)$">
     Order allow,deny
     Deny from all
 </FilesMatch>

--- a/src/model/rolespermisos.php
+++ b/src/model/rolespermisos.php
@@ -12,6 +12,8 @@ class Rolespermisos
    private Database $database;
    private static $routes;
    private array $modulos;
+   private const CACHE_DIR = __DIR__ . '/../../cache/permisos';
+   private const CACHE_FILE = 'permisos_cache.txt';
 
    public function __construct(Database $database)
    {
@@ -28,8 +30,78 @@ class Rolespermisos
          'bitacora' => 9,
       ];
    }
+   private static function verificarDirectorioCache(): void
+   {
+      if (!file_exists(self::CACHE_DIR)) {
+         mkdir(self::CACHE_DIR, 0755, true);
+      }
+   }
+
+   private static function obtenerDirectorioCache(): string
+   {
+      return self::CACHE_DIR . '/' . self::CACHE_FILE;
+   }
+
+   private static function obtenerClaveCache(?int $idRol, ?string $modulo = null): string
+   {
+      if ($idRol === null) {
+         ExceptionHandler::throwException("ID de rol no ingresado", 403, \InvalidArgumentException::class);
+      }
+      
+      $key = 'rol_' . $idRol;
+      if ($modulo !== null) {
+         $key .= '_' . strtolower($modulo);
+      }
+      
+      return $key;
+   }
+
+   private static function obtenerPermisosCache(string $key): ?array
+   {
+      $cacheFile = self::obtenerDirectorioCache();
+      if (!file_exists($cacheFile)) {
+         return null;
+      }
+      
+      $cachedData = @file_get_contents($cacheFile);
+      if ($cachedData === false) {
+         return null;
+      }
+      
+      $data = json_decode($cachedData, true);
+      return $data[$key] ?? null;
+   }
+
+   private static function guardarPermisosCache(string $key, array $data): void
+   {
+      self::verificarDirectorioCache();
+      $cacheFile = self::obtenerDirectorioCache();
+      
+      $cachedData = [];
+      if (file_exists($cacheFile)) {
+         $cachedContent = @file_get_contents($cacheFile);
+         if ($cachedContent !== false) {
+            $cachedData = json_decode($cachedContent, true) ?: [];
+         }
+      }
+      
+      $cachedData[$key] = $data;
+      file_put_contents($cacheFile, json_encode($cachedData), LOCK_EX);
+   }
+
+   public static function limpiarPermisosCache(): void
+   {
+      $cacheFile = self::obtenerDirectorioCache();
+      if (file_exists($cacheFile)) {
+         unlink($cacheFile);
+      }
+   }
+
    public static function obtenerPermisosModulo(string $modulo, Database $database): array
    {
+      // Normalizar el nombre del módulo a minúsculas
+      $modulo = strtolower($modulo);
+      
       self::$routes = require dirname(__DIR__) . "/core/routes.php";
       $esPublica = !empty(self::$routes[$modulo]['public']);
       $obj = new self($database);
@@ -37,67 +109,123 @@ class Rolespermisos
          ? ID_USUARIO
          : null;
       $idRol = null;
+      
       if ($idUsuario) {
          $rolInfo = $obj->obtenerRolUsuario(['id' => $idUsuario]);
          $idRol = Cipher::aesDecrypt($rolInfo['rol']['id_rol']) ?? null;
       }
+      
       if (empty($idRol)) {
          if ($esPublica) {
-            // Ruta pública + sin usuario da permiso de sólo lectura
-            return [
-               'leer'      => 1,
-            ];
+            return ['leer' => 1];
          }
-         // Ruta protegida + sin rol denega acceso
          ExceptionHandler::throwException(
             "Acceso no autorizado",
             403,
             \UnexpectedValueException::class
          );
       }
+      
+      // Obtener todos los permisos del rol desde la caché o la base de datos
+      $permisosRol = self::obtenerTodosLosPermisosRol($idRol, $database);
+      
+      // Devolver solo los permisos del módulo solicitado
+      return $permisosRol[$modulo] ?? ['leer' => 0];
+   }
+   
+   private static function obtenerTodosLosPermisosRol(int $idRol, Database $database): array
+   {
+      $cacheKey = self::obtenerClaveCache($idRol);
+      $cached = self::obtenerPermisosCache($cacheKey);
+      
+      if ($cached !== null) {
+         return $cached;
+      }
+      
+      // Si no está en caché, obtener todos los permisos del rol de la base de datos
       $sql = "SELECT
-                  m.id_modulo,
-                  m.nombre,
+                  m.nombre as modulo,
                   p.crear,
                   p.leer,
                   p.actualizar,
                   p.eliminar
             FROM {$_ENV['SECURE_DB']}.permisos p
             INNER JOIN {$_ENV['SECURE_DB']}.modulos m ON p.modulo = m.id_modulo
-            WHERE p.id_rol = :id_rol 
-               AND m.nombre = :modulo;";
-      $valores = [
-         ':id_rol' => $idRol,
-         ':modulo' => $modulo
-      ];
-      $permisos = $database->query($sql, $valores, true);
-      if (empty($permisos)) {
-         $permisos = [
-            'leer'      => 0,
-         ];
+            WHERE p.id_rol = :id_rol";
+      
+      $permisos = $database->query($sql, [':id_rol' => $idRol]);
+      
+      // Organizar los permisos por módulo
+      $permisosOrganizados = [];
+      foreach ($permisos as $permiso) {
+         $modulo = strtolower($permiso['modulo']);
+         unset($permiso['modulo']);
+         $permisosOrganizados[$modulo] = $permiso;
       }
-      return $permisos;
+      
+      // Guardar en caché todos los permisos del rol
+      self::guardarPermisosCache($cacheKey, $permisosOrganizados);
+      
+      return $permisosOrganizados;
    }
 
    public static function obtenerPermisosNav(Database $database): array|bool
    {
-      $consultaRol = "SELECT p.id_rol FROM {$_ENV['SECURE_DB']}.permisos p
-         INNER JOIN {$_ENV['SECURE_DB']}.usuarios_roles ur ON ur.id_rol = p.id_rol
-         WHERE ur.id_usuario = :id_usuario LIMIT 1;";
-      $idRol = $database->query($consultaRol, [":id_usuario" => ID_USUARIO], true)['id_rol'];
-      $consulta = "SELECT m.id_modulo, m.nombre, p.leer FROM {$_ENV['SECURE_DB']}.permisos p
-                            INNER JOIN {$_ENV['SECURE_DB']}.modulos m ON p.modulo = m.id_modulo
-                            WHERE p.id_rol = :id_rol;";
-      $valores = [':id_rol' => $idRol];
-      $respuesta = $database->query($consulta, $valores);
-      $consulta = "SELECT CONCAT(u.nombre, ' ', u.apellido) as nombre,
-                     r.nombre as rol FROM {$_ENV['SECURE_DB']}.usuarios u
-                     JOIN {$_ENV['SECURE_DB']}.roles r ON r.id_rol = :id_rol
-                     WHERE u.cedula = :id_usuario;";
-      $valores = [':id_rol' => $idRol, ':id_usuario' => ID_USUARIO];
-      $respuestaUsuario = $database->query($consulta, $valores, true);
-      $respuesta['usuario'] = $respuestaUsuario;
-      return $respuesta;
+      if (!defined('ID_USUARIO') || empty(ID_USUARIO)) {
+         return [];
+      }
+      
+      $cacheKey = 'nav_' . ID_USUARIO;
+      $cached = self::obtenerPermisosCache($cacheKey);
+      if ($cached !== null) {
+         return $cached;
+      }
+      
+      // Obtener el ID del rol del usuario
+      $consultaRol = "SELECT ur.id_rol, r.nombre as nombre_rol 
+                     FROM {$_ENV['SECURE_DB']}.usuarios_roles ur
+                     JOIN {$_ENV['SECURE_DB']}.roles r ON r.id_rol = ur.id_rol
+                     WHERE ur.id_usuario = :id_usuario LIMIT 1;";
+      
+      $rolInfo = $database->query($consultaRol, [":id_usuario" => ID_USUARIO], true);
+      
+      if (empty($rolInfo) || !isset($rolInfo['id_rol'])) {
+         return [];
+      }
+      
+      $idRol = $rolInfo['id_rol'];
+      
+      // Obtener todos los permisos del rol (usará la caché si está disponible)
+      $permisosRol = self::obtenerTodosLosPermisosRol($idRol, $database);
+      
+      // Formatear los permisos para la navegación
+      $permisosNav = [];
+      foreach ($permisosRol as $modulo => $permiso) {
+         $permisosNav[] = [
+            'nombre' => $modulo,
+            'leer' => $permiso['leer'] ?? 0
+         ];
+      }
+      
+      // Obtener información del usuario
+      $consultaUsuario = "SELECT CONCAT(nombre, ' ', apellido) as nombre 
+                         FROM {$_ENV['SECURE_DB']}.usuarios 
+                         WHERE cedula = :id_usuario;";
+      
+      $usuario = $database->query($consultaUsuario, [':id_usuario' => ID_USUARIO], true);
+      
+      $resultado = [
+         ...$permisosNav,
+         'usuario' => [
+            'nombre' => $usuario['nombre'] ?? 'Usuario',
+            'rol' => $rolInfo['nombre_rol']
+         ]
+      ];
+      
+      // Guardar en caché
+      self::guardarPermisosCache($cacheKey, $resultado);
+      
+      return $resultado;
    }
    public function obtenerRol(array $datos): array
    {
@@ -125,13 +253,16 @@ class Rolespermisos
       $idRol = Cipher::aesDecrypt($arrayFiltrado['id_rol_asignar']);
       Validar::sanitizarYValidar($idRol, 'int');
       Validar::validar("cedula", $arrayFiltrado['cedula']);
-      return $this->_asignarRol($idRol, $arrayFiltrado['cedula']);
+      $resultado = $this->_asignarRol($idRol, $arrayFiltrado['cedula']);
+      self::limpiarPermisosCache();
+      return $resultado;
    }
    public function incluirRol(array $datos): array
    {
       Validar::validar("nombre_rol", $datos['nombre_rol']);
       $arrayPermisos = $this->arrayValoresPermisos($datos);
-      return $this->_incluirRol($datos['nombre_rol'], $arrayPermisos);
+      $resultado = $this->_incluirRol($datos['nombre_rol'], $arrayPermisos);
+      return $resultado;
    }
    public function modificarRol(array $datos): array
    {
@@ -140,7 +271,9 @@ class Rolespermisos
       $idRol = Cipher::aesDecrypt($datos['id_rol']);
       Validar::sanitizarYValidar($idRol, 'int');
       Validar::sanitizarYValidar($datos['nombre_rol'], 'string');
-      return $this->_modificarRol($idRol, $datos['nombre_rol'], $arrayPermisos);
+      $resultado = $this->_modificarRol($idRol, $datos['nombre_rol'], $arrayPermisos);
+      self::limpiarPermisosCache();
+      return $resultado;
    }
 
    public function eliminarRol(array $datos): array
@@ -149,7 +282,9 @@ class Rolespermisos
       $arrayFiltrado = Validar::validarArray($datos, $keys);
       $idRolDesencriptado = Cipher::aesDecrypt($arrayFiltrado['id_rol']);
       Validar::sanitizarYValidar($idRolDesencriptado, 'int');
-      return $this->_eliminarRol($idRolDesencriptado);
+      $resultado = $this->_eliminarRol($idRolDesencriptado);
+      self::limpiarPermisosCache();
+      return $resultado;
    }
 
    private function _incluirRol(string $nombre, array $permisos): array

--- a/src/utils/LoginAttempts.php
+++ b/src/utils/LoginAttempts.php
@@ -49,10 +49,19 @@ class LoginAttempts
       return true;
    }
 
+   private static function verificarDirectorioCache(): void
+   {
+      if (!file_exists(self::CACHE_DIR)) {
+         mkdir(self::CACHE_DIR, 0755, true);
+      }
+   }
+
    public static function recordFailedAttempt(): void
    {
       $file = self::getCacheFile();
       $data = ['attempts' => 1, 'timestamp' => time()];
+      
+      self::verificarDirectorioCache();
 
       if (file_exists($file)) {
          $currentData = json_decode(file_get_contents($file), true);
@@ -79,7 +88,15 @@ class LoginAttempts
 
    public static function limpiarCacheIntentos(): int
    {
+      if (!file_exists(self::CACHE_DIR)) {
+         return 0;
+      }
+      
       $files = glob(self::CACHE_DIR . '/login_attempts_*.txt');
+      if ($files === false) {
+         return 0;
+      }
+      
       $now = time();
       $archivosLimpiados = 0;
       foreach ($files as $file) {


### PR DESCRIPTION
Se implementó caché para permisos de navbar y de modulos, para reducir la cantidad de consultas innecesarias. Además el caché de login attempts ahora verifica si la carpeta existe, para crearla.